### PR TITLE
Move file save to seperate process to help GUI responsiveness

### DIFF
--- a/TheBeginningObject.ino
+++ b/TheBeginningObject.ino
@@ -1,6 +1,7 @@
 /*Using LVGL with Arduino requires some extra steps:
  *Be sure to read the docs here: https://docs.lvgl.io/master/get-started/platforms/arduino.html  */
 
+
 #include <lvgl.h>
 #include <driver/i2c.h>
 #include <OneWire.h>
@@ -19,27 +20,39 @@ LGFX lcd;
 
 uint8_t initErrors = 0;
 
-
-
 /*LVGL draw into this buffer, 1/10 screen size usually works well. The size is in bytes*/
 const unsigned int lvBufferSize = (TFT_HOR_RES * TFT_VER_RES * 2) / 10;
 void *lvBuffer1 = malloc(lvBufferSize);
 void *lvBuffer2 = malloc(lvBufferSize);
 
-
-//All is managed in this file, because the libs FS,SD require C++, so all the other files can trigger this method here 
-void eventSave(lv_event_t * e)
-{
-  lv_event_code_t code = lv_event_get_code(e);
-  if(code == LV_EVENT_REFRESH){
-    LV_LOG_USER("Save JSON!");
-    //TEMPORARY DISABLED, BUT WORKING!
-    writeFullJSONFile(SD, FILENAME_SAVE,gui);
-  }
-    
-    
+#define LVGL_TICK_PERIOD_MS    1
+static void increase_lvgl_tick( void *arg ) {
+  lv_tick_inc(LVGL_TICK_PERIOD_MS);
 }
 
+void sysMan( void *arg ) {
+
+  uint16_t  msg;
+		
+	while(1) {  // This is a task which runs for ever
+		
+		if( xQueueReceive( gui.sysActionQ, &msg, portMAX_DELAY ) ) {
+			switch(msg) {
+
+			case SAVE_PROCESS_CONFIG:
+	        LV_LOG_USER("Save JSON!");
+          writeFullJSONFile(SD, FILENAME_SAVE,gui);
+          break;
+
+      // Add Further processor intensive tasks here to keep them out of the GUI execution path
+
+      default:
+          LV_LOG_USER( "Unknown System Manager Request!");
+          break;
+      }
+    }
+	}
+}
 
 void setup()
 {
@@ -57,6 +70,16 @@ void setup()
     lcd.setRotation(1);
 
     SPI.begin(SD_SCLK, SD_MISO, SD_MOSI);
+
+    LV_LOG_USER("Install LVGL tick timer");
+    // Tick interface for LVGL (using esp_timer to generate LVGL_TICK_PERIOD_MS periodic event)
+    const esp_timer_create_args_t lvgl_tick_timer_args = {
+        .callback = increase_lvgl_tick,
+        .name = "lvgl_tick"
+    };
+    esp_timer_handle_t lvgl_tick_timer = NULL;
+    esp_timer_create(&lvgl_tick_timer_args, &lvgl_tick_timer);
+    esp_timer_start_periodic(lvgl_tick_timer, LVGL_TICK_PERIOD_MS * 1000);
 
     lv_init();
 
@@ -76,11 +99,12 @@ void setup()
  
     initSD_I2C();
     homePage();
-    
-    fakeObjectForSave = lv_obj_create(NULL);
 
-    lv_obj_add_event_cb(fakeObjectForSave, eventSave, LV_EVENT_REFRESH, NULL);  
-
+    /* Create System message queue */
+    gui.sysActionQ = xQueueCreate( 16, sizeof( uint16_t ) );
+    /* Create task to process external functions which will slow the GUI response */							
+    xTaskCreatePinnedToCore( sysMan, "sysMan", 4096, NULL, 8,  NULL, 0 ); 
+ 
     //writeFile(SD, FILENAME_SAVE, "Hello, this is a test file\n");
     //writeJSONFile(SD, FILENAME_SAVE, gui.page.settings.settingsParams);
     //readFile(SD, FILENAME_SAVE);
@@ -93,8 +117,7 @@ void setup()
 
 void loop()
 {
-    delay(1);
-    lv_tick_inc(1);
     lv_task_handler(); /* let the GUI do its work */
+    delay(5);
 }
 

--- a/include/accessory.c
+++ b/include/accessory.c
@@ -30,6 +30,12 @@ struct gui_components	gui;
 extern LGFX lcd;
 void (*rebootBoard)(void) = 0;
 
+/* Put a system request in the queue returns true if succesful false if queue is full */
+uint8_t qSysAction( uint16_t msg ) {
+  
+  return xQueueSend( gui.sysActionQ, &msg, 0 );
+}
+
 void event_cb(lv_event_t * e)
 {
   lv_event_code_t code = lv_event_get_code(e);

--- a/include/definitions.h
+++ b/include/definitions.h
@@ -7,6 +7,8 @@
 #ifndef DEFINITIONS_H
 #define DEFINITIONS_H
 
+#include "FreeRTOS.h"
+#include "semphr.h"
 /*********************
 *LovyanGFX Parameters 
 *********************/
@@ -477,7 +479,7 @@ typedef struct sProcessDetail {
     uint8_t            isTempControlled;
     uint8_t            isPreferred;
     uint8_t            somethingChanged;
-    filmType_t           filmType;
+    filmType_t          filmType;
     uint8_t            timeMins;
     uint8_t            timeSecs;
 }sProcessDetail;
@@ -812,12 +814,18 @@ struct sPages {
 struct gui_components {
 	struct sElements	element;
 	struct sPages		  page;
+  QueueHandle_t			sysActionQ;
 };
 
 
 /*********************
 * GLOBAL DEFINES
 *********************/
+
+/*********************
+* System manager defines
+*********************/
+#define SAVE_PROCESS_CONFIG   0x0001
 
 LV_FONT_DECLARE(FilMachineFontIcons_15);
 LV_FONT_DECLARE(FilMachineFontIcons_20);
@@ -1159,7 +1167,6 @@ unsigned long actualMillis;
 processNode	* tempProcessNode;
 stepNode	  * tempStepNode;
 
-lv_obj_t    *fakeObjectForSave;
 extern uint8_t initErrors;
 char formatted_string[20];
 
@@ -1239,6 +1246,7 @@ void tools(void);
 
 
 // @file accessory.c
+uint8_t qSysAction( uint16_t msg );
 lv_obj_t * create_radiobutton(lv_obj_t * mBoxParent, const char * txt, const int32_t x, const int32_t y, const int32_t size, const lv_font_t * font, const lv_color_t borderColor, const lv_color_t bgColor);
 lv_obj_t * create_text(lv_obj_t * parent, const char * icon, const char * txt);
 lv_obj_t * create_slider(lv_obj_t * parent, const char * icon, const char * txt, int32_t min, int32_t max,int32_t val);
@@ -1273,7 +1281,7 @@ void my_disp_flush(lv_display_t* display, const lv_area_t* area, unsigned char* 
 void my_touchpad_read(lv_indev_t* dev, lv_indev_data_t* data);
 
 //@file THeBeginningObject.ino
-void eventSave(lv_event_t * e);
+//void eventSave(lv_event_t * e);
 
 extern void (*rebootBoard)(void);
 #ifdef __cplusplus

--- a/src/elements/element_filterPopup.c
+++ b/src/elements/element_filterPopup.c
@@ -33,7 +33,7 @@ void event_filterMBox(lv_event_t * e){
           lv_obj_remove_state(gui.element.filterPopup.mBoxSelectColorRadioButton, LV_STATE_CHECKED);
           lv_obj_remove_state(gui.element.filterPopup.mBoxSelectBnWRadioButton, LV_STATE_CHECKED);
           lv_obj_remove_state(gui.element.filterPopup.mBoxOnlyPreferredSwitch, LV_STATE_CHECKED);
-          lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+          qSysAction( SAVE_PROCESS_CONFIG );
         }
         if(obj == gui.element.filterPopup.mBoxResetFilterButton){
           LV_LOG_USER("Reset BUTTON");
@@ -46,7 +46,7 @@ void event_filterMBox(lv_event_t * e){
           gui.element.filterPopup.isBnWFilter = 0;
           gui.element.filterPopup.preferredOnly = 0;
           gui.element.filterPopup.filterName = "";
-          lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+          qSysAction( SAVE_PROCESS_CONFIG );
         }
       }
   }
@@ -61,14 +61,14 @@ void event_filterMBox(lv_event_t * e){
           LV_LOG_USER("State bnw: %s", lv_obj_has_state(obj, LV_STATE_CHECKED) ? "On" : "Off");
           gui.element.filterPopup.isBnWFilter = lv_obj_has_state(obj, LV_STATE_CHECKED);
           }
-        lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+          qSysAction( SAVE_PROCESS_CONFIG );
       }
     }
   if(obj == gui.element.filterPopup.mBoxOnlyPreferredSwitch){
     if(code == LV_EVENT_VALUE_CHANGED) {
         LV_LOG_USER("State preferred: %s", lv_obj_has_state(obj, LV_STATE_CHECKED) ? "On" : "Off");
         gui.element.filterPopup.preferredOnly = lv_obj_has_state(obj, LV_STATE_CHECKED);  
-        lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+        qSysAction( SAVE_PROCESS_CONFIG );
       }
     }
 }

--- a/src/elements/element_messagePopup.c
+++ b/src/elements/element_messagePopup.c
@@ -105,7 +105,7 @@ void event_messagePopup(lv_event_t *e)
                   LV_LOG_USER("Delete ALL PROCESS!");
                   gui.page.processes.processElementsList.start = NULL;
                   lv_obj_clean(gui.page.processes.processesListContainer);
-                  lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+                  qSysAction( SAVE_PROCESS_CONFIG );
                 }else {
                     LV_LOG_USER("Processes already empty");
                 }

--- a/src/elements/element_rollerPopup.c
+++ b/src/elements/element_rollerPopup.c
@@ -33,7 +33,7 @@ void event_Roller(lv_event_t * e)
               lv_msgbox_close(godFatherCont);
               lv_obj_delete(godFatherCont);
               gui.page.settings.settingsParams.calibratedTemp = rollerSelected;  
-              lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+              qSysAction( SAVE_PROCESS_CONFIG );
               return;   
             }
             if((lv_obj_t *)data == tempProcessNode->process.processDetails->processTempTextArea){

--- a/src/pages/page_processDetail.c
+++ b/src/pages/page_processDetail.c
@@ -80,12 +80,12 @@ void event_processDetail(lv_event_t * e)
           if(addProcessElement(newProcess) != NULL){
              LV_LOG_USER("Process not present yet, let's create!");
              processElementCreate(newProcess);
-             lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+             qSysAction( SAVE_PROCESS_CONFIG );
           }    
             else{
                   LV_LOG_USER("Process element creation failed, maximum entries reached" );
             }
-        lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+          qSysAction( SAVE_PROCESS_CONFIG );
         updateProcessElement(newProcess);
         LV_LOG_USER("Pressed processSaveButton");
     }
@@ -326,7 +326,7 @@ if(existingProcess != NULL) {
                           lv_obj_align(newProcess->process.processDetails->processTempTextArea, LV_ALIGN_LEFT_MID, 100, 0);
                           lv_obj_set_width(newProcess->process.processDetails->processTempTextArea, 60);
                           lv_obj_add_event_cb(newProcess->process.processDetails->processTempTextArea, event_processDetail, LV_EVENT_ALL, newProcess->process.processDetails->processTempTextArea);
-                          lv_obj_add_state(newProcess->process.processDetails->processTempTextArea, LV_STATE_FOCUSED);
+//                          lv_obj_add_state(newProcess->process.processDetails->processTempTextArea, LV_STATE_FOCUSED);
                           lv_obj_set_style_bg_color(newProcess->process.processDetails->processTempTextArea, lv_palette_darken(LV_PALETTE_GREY, 3), 0);
                           lv_obj_set_style_text_align(newProcess->process.processDetails->processTempTextArea , LV_TEXT_ALIGN_CENTER, 0);
                           lv_style_set_text_font(&newProcess->process.processDetails->textAreaStyle, &lv_font_montserrat_18);
@@ -368,7 +368,7 @@ if(existingProcess != NULL) {
                           lv_obj_set_width(newProcess->process.processDetails->processToleranceTextArea, 60);
 
                           lv_obj_add_event_cb(newProcess->process.processDetails->processToleranceTextArea, event_processDetail, LV_EVENT_ALL, newProcess->process.processDetails->processToleranceTextArea);
-                          lv_obj_add_state(newProcess->process.processDetails->processToleranceTextArea, LV_STATE_FOCUSED);
+//                          lv_obj_add_state(newProcess->process.processDetails->processToleranceTextArea, LV_STATE_FOCUSED);
                           lv_obj_set_style_bg_color(newProcess->process.processDetails->processToleranceTextArea, lv_palette_darken(LV_PALETTE_GREY, 3), 0);
                           lv_obj_set_style_text_align(newProcess->process.processDetails->processToleranceTextArea , LV_TEXT_ALIGN_CENTER, 0);
                           lv_style_set_text_font(&newProcess->process.processDetails->textAreaStyle, &lv_font_montserrat_18);

--- a/src/pages/page_settings.c
+++ b/src/pages/page_settings.c
@@ -79,7 +79,7 @@ void event_settings_handler(lv_event_t * e)
             *active_id = lv_obj_get_index(act_cb);
             LV_LOG_USER("Selected °C or °F: %d", (int)gui.page.settings.active_index);
             gui.page.settings.settingsParams.tempUnit = (int)gui.page.settings.active_index;
-            lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+            qSysAction( SAVE_PROCESS_CONFIG );
        }
     }
  
@@ -87,7 +87,7 @@ void event_settings_handler(lv_event_t * e)
       if(code == LV_EVENT_VALUE_CHANGED) {
           LV_LOG_USER("State Inlet: %s", lv_obj_has_state(act_cb, LV_STATE_CHECKED) ? "On" : "Off");
           gui.page.settings.settingsParams.waterInlet = lv_obj_has_state(act_cb, LV_STATE_CHECKED);
-          lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+          qSysAction( SAVE_PROCESS_CONFIG );
         }
     }
 
@@ -109,7 +109,7 @@ void event_settings_handler(lv_event_t * e)
           gui.page.settings.settingsParams.filmRotationSpeedSetpoint = lv_slider_get_value(act_cb);
         }
       if(code == LV_EVENT_RELEASED){
-          lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+          qSysAction( SAVE_PROCESS_CONFIG );
         }
     }
 
@@ -120,7 +120,7 @@ void event_settings_handler(lv_event_t * e)
           gui.page.settings.settingsParams.rotationIntervalSetpoint = lv_slider_get_value(act_cb);
         }
       if(code == LV_EVENT_RELEASED){
-          lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+          qSysAction( SAVE_PROCESS_CONFIG );
         }    }
 
     if(act_cb == gui.page.settings.filmRandomlSlider){
@@ -130,14 +130,14 @@ void event_settings_handler(lv_event_t * e)
         gui.page.settings.settingsParams.randomSetpoint = lv_slider_get_value(act_cb);
         }
       if(code == LV_EVENT_RELEASED){
-          lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+          qSysAction( SAVE_PROCESS_CONFIG );
         }    }
 
     if(act_cb == gui.page.settings.persistentAlarmSwitch){
       if(code == LV_EVENT_VALUE_CHANGED) {
           LV_LOG_USER("Persistent Alarm: %s", lv_obj_has_state(act_cb, LV_STATE_CHECKED) ? "On" : "Off");
           gui.page.settings.settingsParams.isPersistentAlarm = lv_obj_has_state(act_cb, LV_STATE_CHECKED);
-          lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+          qSysAction( SAVE_PROCESS_CONFIG );
         }
     }
 
@@ -145,7 +145,7 @@ void event_settings_handler(lv_event_t * e)
       if(code == LV_EVENT_VALUE_CHANGED) {
           LV_LOG_USER("Autostart : %s", lv_obj_has_state(act_cb, LV_STATE_CHECKED) ? "On" : "Off");
           gui.page.settings.settingsParams.isProcessAutostart = lv_obj_has_state(act_cb, LV_STATE_CHECKED);
-          lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+          qSysAction( SAVE_PROCESS_CONFIG );
         }
     }
     
@@ -156,7 +156,7 @@ void event_settings_handler(lv_event_t * e)
           gui.page.settings.settingsParams.drainFillOverlapSetpoint = lv_slider_get_value(act_cb);
           }
       if(code == LV_EVENT_RELEASED){
-          lv_obj_send_event(fakeObjectForSave, LV_EVENT_REFRESH, NULL);
+          qSysAction( SAVE_PROCESS_CONFIG );
         }    }
 }
 

--- a/src/pages/page_stepDetail.c
+++ b/src/pages/page_stepDetail.c
@@ -223,7 +223,8 @@ void stepDetail(processNode * referenceNode, stepNode * currentNode)
                   lv_obj_set_width(newStep->step.stepDetails->stepDetailMinTextArea, 60);
                  
                   lv_obj_add_event_cb(newStep->step.stepDetails->stepDetailMinTextArea, event_stepDetail, LV_EVENT_ALL, newStep->step.stepDetails->stepDetailMinTextArea);
-                  lv_obj_add_state(newStep->step.stepDetails->stepDetailMinTextArea, LV_STATE_FOCUSED); 
+//                  lv_textarea_set_cursor_hidden(newStep->step.stepDetails->stepDetailMinTextArea, true);
+//                  lv_obj_add_state(newStep->step.stepDetails->stepDetailMinTextArea, LV_STATE_FOCUSED); 
                   lv_obj_set_style_bg_color(newStep->step.stepDetails->stepDetailMinTextArea, lv_palette_darken(LV_PALETTE_GREY, 3), 0);
                   lv_obj_set_style_text_align(newStep->step.stepDetails->stepDetailMinTextArea , LV_TEXT_ALIGN_CENTER, 0);
                   lv_obj_set_style_border_color(newStep->step.stepDetails->stepDetailMinTextArea, lv_color_hex(WHITE), 0);
@@ -232,13 +233,14 @@ void stepDetail(processNode * referenceNode, stepNode * currentNode)
 
 
                   newStep->step.stepDetails->stepDetailSecTextArea = lv_textarea_create(newStep->step.stepDetails->stepDurationContainer);
+//                  lv_textarea_set_cursor_hidden(newStep->step.stepDetails->stepDetailSecTextArea, true);
                   lv_textarea_set_one_line(newStep->step.stepDetails->stepDetailSecTextArea, true);
                   lv_textarea_set_placeholder_text(newStep->step.stepDetails->stepDetailSecTextArea, stepDetailDurationSecPlaceHolder_text);
                   lv_obj_align(newStep->step.stepDetails->stepDetailSecTextArea, LV_ALIGN_LEFT_MID, 187, 0);
                   lv_obj_set_width(newStep->step.stepDetails->stepDetailSecTextArea, 60);
 
                   lv_obj_add_event_cb(newStep->step.stepDetails->stepDetailSecTextArea, event_stepDetail, LV_EVENT_ALL, newStep->step.stepDetails->stepDetailSecTextArea);
-                  lv_obj_add_state(newStep->step.stepDetails->stepDetailSecTextArea, LV_STATE_FOCUSED); 
+//                  lv_obj_add_state(newStep->step.stepDetails->stepDetailSecTextArea, LV_STATE_FOCUSED); 
                   lv_obj_set_style_bg_color(newStep->step.stepDetails->stepDetailSecTextArea, lv_palette_darken(LV_PALETTE_GREY, 3), 0);
                   lv_obj_set_style_text_align(newStep->step.stepDetails->stepDetailSecTextArea , LV_TEXT_ALIGN_CENTER, 0);
                   lv_obj_set_style_border_color(newStep->step.stepDetails->stepDetailSecTextArea, lv_color_hex(WHITE), 0);


### PR DESCRIPTION
Created a seperate sysMan task on CPU core 0 to process file save events removing the need for the fake object and event codes, this also improves the performance of the GUI by not having it take place in the GUI code execution loop.  The sysMan task can now be expanded to carry out any tasks that would block the GUI.  Also created an interrupt driven timer to increment lv_tick to improve GUI responsiveness.

Changes To Be Committed:
-	modified:   TheBeginningObject.ino
-	modified:   include/accessory.c
-	modified:   include/definitions.h
-	modified:   src/elements/element_filterPopup.c
-	modified:   src/elements/element_messagePopup.c
-	modified:   src/elements/element_rollerPopup.c
-	modified:   src/pages/page_processDetail.c
-	modified:   src/pages/page_settings.c
-	modified:   src/pages/page_stepDetail.c